### PR TITLE
Fix backend session imports and card refreeze

### DIFF
--- a/backend/src/controllers/cardController.js
+++ b/backend/src/controllers/cardController.js
@@ -1,6 +1,10 @@
 
 const { getCardByUserId, updateCardStatus } = require('../models/card');
-const { createAuthSession, getActiveSessionByUserId } = require('../models/authSession');
+const {
+  createAuthSession,
+  getActiveSessionByUserId,
+  updateSessionStatus
+} = require('../models/authSession');
 const { unfreezeCard, freezeCardLithic, getCardDetails: getLithicCardDetails } = require('../services/lithic');
 const { client: redisClient } = require('../config/redis');
 const logger = require('../utils/logger');

--- a/backend/src/controllers/webhookController.js
+++ b/backend/src/controllers/webhookController.js
@@ -1,6 +1,6 @@
 
 const crypto = require('crypto');
-const { getCardByLithicId } = require('../models/card');
+const { getCardByLithicId, getCardById } = require('../models/card');
 const { createTransaction, getTransactionByLithicId, updateTransactionStatus } = require('../models/transaction');
 const { getActiveSessionByUserId, updateSessionStatus } = require('../models/authSession');
 const { updateBudgetSpent } = require('../models/budget');
@@ -149,7 +149,7 @@ const handleTransactionSettled = async (transaction) => {
     // This is a simplified implementation - in production, you'd have more sophisticated budget matching
     
     // Automatically refreeze card after successful transaction
-    const card = await getCardByLithicId(transaction.card_id);
+  const card = await getCardById(transaction.card_id);
     if (card) {
       await freezeCardLithic(card.lithic_card_id);
       await updateCardStatus(card.id, 'frozen');


### PR DESCRIPTION
## Summary
- add missing `updateSessionStatus` import
- ensure card lookup by ID in webhook controller

## Testing
- `npm test` *(fails: no tests specified)*

------
https://chatgpt.com/codex/tasks/task_e_6846fe9409b08328adbe5a93f9f99802