### PR TITLE
Fix missing next-themes dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -46,7 +46,8 @@
     "@radix-ui/react-toast": "^1.0.0",
     "@radix-ui/react-toggle": "^1.0.0",
     "@radix-ui/react-toggle-group": "^1.0.0",
-    "@radix-ui/react-tooltip": "^1.0.0"
+    "@radix-ui/react-tooltip": "^1.0.0",
+    "next-themes": "^0.4.6"
   },
   "devDependencies": {
     "autoprefixer": "^10.4.14",


### PR DESCRIPTION
## Summary
- add `next-themes` to frontend dependencies

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6847388c3e808328b35fd4f559fbacac