### PR TITLE
Remove build types from tsconfig

### DIFF
--- a/frontend/app/tsconfig.json
+++ b/frontend/app/tsconfig.json
@@ -32,8 +32,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".build/types/**/*.ts"
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -32,8 +32,7 @@
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts",
-    ".build/types/**/*.ts"
+    ".next/types/**/*.ts"
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
## Summary
- avoid including `.build/types` in tsconfig to prevent build errors

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68473fec5f9483288eb4105009f1c888