### PR TITLE
Remove broken API documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,4 +182,3 @@ For support and questions, please open an issue in the GitHub repository.
 
 - [Backend Documentation](./backend/README.md)
 - [Frontend Documentation](./frontend/README.md)
-- [API Documentation](./docs/api.md)


### PR DESCRIPTION
## Summary
- remove link to missing `docs/api.md` in root README

## Testing
- `npm test --silent` in `backend`
- `npm test --silent` in `frontend` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68474865be2c8328bcbbb4a34084b034