### PR TITLE
Fix Prisma client path

### DIFF
--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -5,7 +5,8 @@
 generator client {
     provider = "prisma-client-js"
     binaryTargets = ["native", "linux-musl-arm64-openssl-3.0.x"]
-    output = "/home/ubuntu/finlock-frontend/node_modules/.prisma/client"
+    // Use a path relative to this schema so the client works in any environment
+    output = "../node_modules/.prisma/client"
 }
 
 datasource db {


### PR DESCRIPTION
## Summary
- use a relative path for the Prisma client generator

## Testing
- `PRISMA_ENGINES_CHECKSUM_IGNORE_MISSING=1 npx prisma@5.9.0 generate --schema prisma/schema.prisma` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684748799160832889ca33fd5da1d6a3