### PR TITLE
Fix port references in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ npm run migrate
 npm run dev
 ```
 
-The backend will be available at `http://localhost:3001`
+The backend will be available at `http://localhost:3000`
 
 ### Frontend Setup
 
@@ -126,12 +126,12 @@ DATABASE_URL=postgresql://username:password@localhost:5432/finlock
 REDIS_URL=redis://localhost:6379
 JWT_SECRET=your-jwt-secret
 LITHIC_API_KEY=your-lithic-api-key
-PORT=3001
+PORT=3000
 ```
 
 ### Frontend Environment Variables
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_APP_NAME=FinLock
 ```
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,2 +1,2 @@
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_APP_NAME=FinLock

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -52,6 +52,6 @@ src/
 ## Environment Variables
 
 ```env
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:3000
 NEXT_PUBLIC_APP_NAME=FinLock
 ```


### PR DESCRIPTION
## Summary
- update localhost references from 3001 to 3000
- keep README configuration consistent with .env.example

## Testing
- `npm test --prefix backend`

------
https://chatgpt.com/codex/tasks/task_e_68474860946c8328a27ab52a4e2d46fc