### PR TITLE
Update API base URL configuration

### DIFF
--- a/frontend/README.md
+++ b/frontend/README.md
@@ -51,6 +51,10 @@ src/
 
 ## Environment Variables
 
+The frontend reads `NEXT_PUBLIC_API_URL` to determine the base URL of the
+backend API. If this variable is not set, the application defaults to
+`http://localhost:3001`.
+
 ```env
 NEXT_PUBLIC_API_URL=http://localhost:3001
 NEXT_PUBLIC_APP_NAME=FinLock

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -1,5 +1,6 @@
 
-const API_BASE_URL = 'http://localhost:3001';
+// Base URL for the API. Falls back to localhost if the env variable is not set.
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
 export interface ApiResponse<T = any> {
   success: boolean;

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,5 +1,8 @@
 
-const API_BASE_URL = 'http://localhost:3001';
+// Determine the base URL for all API requests.
+// `NEXT_PUBLIC_API_URL` is injected by Next.js at build time. If it is
+// not provided, default to the local backend.
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:3001';
 
 export interface ApiResponse<T = any> {
   success: boolean;


### PR DESCRIPTION
## Summary
- read API URL from `NEXT_PUBLIC_API_URL` in API client modules
- clarify env var behaviour in frontend README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847486e21448328ba9f3d574c1deb60