### PR TITLE
Fix history page transactions parsing error

### DIFF
--- a/frontend/app/components/screens/history-screen.tsx
+++ b/frontend/app/components/screens/history-screen.tsx
@@ -38,7 +38,11 @@ export function HistoryScreen() {
     try {
       const response = await apiClient.getTransactions();
       if (response.success && response.data) {
-        setTransactions(response.data);
+        // Handle API response that may wrap transactions in an object
+        const txs = Array.isArray(response.data)
+          ? response.data
+          : (response.data as any).transactions;
+        setTransactions(txs || []);
       } else {
         // Use mock data if API fails
         setTransactions(MOCK_TRANSACTIONS);

--- a/frontend/app/lib/api.ts
+++ b/frontend/app/lib/api.ts
@@ -144,7 +144,12 @@ class ApiClient {
 
   // Transaction endpoints
   async getTransactions(): Promise<ApiResponse<Transaction[]>> {
-    return this.request('/api/transactions');
+    const response = await this.request('/api/transactions');
+    if (response.success && response.data && !Array.isArray(response.data)) {
+      // unwrap { transactions: [...] }
+      return { ...response, data: (response.data as any).transactions };
+    }
+    return response;
   }
 }
 

--- a/frontend/components/screens/history-screen.tsx
+++ b/frontend/components/screens/history-screen.tsx
@@ -38,7 +38,11 @@ export function HistoryScreen() {
     try {
       const response = await apiClient.getTransactions();
       if (response.success && response.data) {
-        setTransactions(response.data);
+        // Handle API response that may wrap transactions in an object
+        const txs = Array.isArray(response.data)
+          ? response.data
+          : (response.data as any).transactions;
+        setTransactions(txs || []);
       } else {
         // Use mock data if API fails
         setTransactions(MOCK_TRANSACTIONS);

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -146,7 +146,12 @@ class ApiClient {
 
   // Transaction endpoints
   async getTransactions(): Promise<ApiResponse<Transaction[]>> {
-    return this.request('/api/transactions');
+    const response = await this.request('/api/transactions');
+    if (response.success && response.data && !Array.isArray(response.data)) {
+      // unwrap { transactions: [...] }
+      return { ...response, data: (response.data as any).transactions };
+    }
+    return response;
   }
 }
 


### PR DESCRIPTION
## Summary
- handle `transactions` API response object in History screens
- unwrap `{ transactions: [...] }` in API client

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6847534ecd4883289d8168b736032e01