### PR TITLE
Add credit card detail screen

### DIFF
--- a/frontend/components/auth/login-form.tsx
+++ b/frontend/components/auth/login-form.tsx
@@ -20,7 +20,7 @@ export function LoginForm({ onToggleMode }: LoginFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const { setUser, setLoading } = useAppStore();
+  const { setUser, setLoading, setCardDetails } = useAppStore();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -33,6 +33,12 @@ export function LoginForm({ onToggleMode }: LoginFormProps) {
       if (response.success && response.data) {
         apiClient.setToken(response.data.token);
         setUser(response.data.user);
+
+        const cardResp = await apiClient.getCardDetails();
+        if (cardResp.success && cardResp.data) {
+          setCardDetails(cardResp.data.card);
+        }
+
         setLoading(false);
       } else {
         setError(response.error || 'Login failed');

--- a/frontend/components/auth/register-form.tsx
+++ b/frontend/components/auth/register-form.tsx
@@ -23,7 +23,7 @@ export function RegisterForm({ onToggleMode }: RegisterFormProps) {
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState('');
 
-  const { setUser, setLoading } = useAppStore();
+  const { setUser, setLoading, setCardDetails } = useAppStore();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -48,6 +48,12 @@ export function RegisterForm({ onToggleMode }: RegisterFormProps) {
       if (response.success && response.data) {
         apiClient.setToken(response.data.token);
         setUser(response.data.user);
+
+        const cardResp = await apiClient.getCardDetails();
+        if (cardResp.success && cardResp.data) {
+          setCardDetails(cardResp.data.card);
+        }
+
         setLoading(false);
       } else {
         setError(response.error || 'Registration failed');

--- a/frontend/components/finlock-app.tsx
+++ b/frontend/components/finlock-app.tsx
@@ -11,6 +11,7 @@ import { SuccessScreen } from '@/components/screens/success-screen';
 import { PostPurchaseScreen } from '@/components/screens/post-purchase-screen';
 import { HistoryScreen } from '@/components/screens/history-screen';
 import { ProfileScreen } from '@/components/screens/profile-screen';
+import { CardScreen } from '@/components/screens/card-screen';
 import { apiClient } from '@/lib/api';
 
 export function FinLockApp() {
@@ -47,6 +48,8 @@ export function FinLockApp() {
         return <HistoryScreen />;
       case 'profile':
         return <ProfileScreen />;
+      case 'card':
+        return <CardScreen />;
       default:
         return <HomeScreen />;
     }

--- a/frontend/components/layout/mobile-header.tsx
+++ b/frontend/components/layout/mobile-header.tsx
@@ -28,6 +28,7 @@ export function MobileHeader() {
 
   const navigation = [
     { id: 'home', label: 'Home', icon: Home },
+    { id: 'card', label: 'Card', icon: CreditCard },
     { id: 'authorize', label: 'Authorize', icon: CreditCard },
     { id: 'history', label: 'History', icon: History },
     { id: 'profile', label: 'Profile', icon: User },

--- a/frontend/components/screens/card-screen.tsx
+++ b/frontend/components/screens/card-screen.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useEffect } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAppStore } from '@/lib/store';
+import { apiClient } from '@/lib/api';
+import { ArrowLeft, CreditCard } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+export function CardScreen() {
+  const { cardDetails, setCardDetails, setCurrentScreen } = useAppStore();
+
+  useEffect(() => {
+    const loadDetails = async () => {
+      const response = await apiClient.getCardDetails();
+      if (response.success && response.data) {
+        setCardDetails(response.data.card);
+      }
+    };
+
+    if (!cardDetails) {
+      loadDetails();
+    }
+  }, [cardDetails, setCardDetails]);
+
+  if (!cardDetails) {
+    return (
+      <div className="flex items-center justify-center min-h-[200px]">
+        <div className="text-center">
+          <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-4"></div>
+          <p className="text-muted-foreground">Loading card information...</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 p-4 max-w-md mx-auto">
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        className="flex items-center space-x-3"
+      >
+        <Button variant="ghost" size="icon" onClick={() => setCurrentScreen('home')}>
+          <ArrowLeft className="h-5 w-5" />
+        </Button>
+        <div>
+          <h1 className="text-xl font-bold">My Card</h1>
+          <p className="text-sm text-muted-foreground">View your card details</p>
+        </div>
+      </motion.div>
+
+      <motion.div
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.1 }}
+      >
+        <Card className="fintech-card">
+          <CardHeader>
+            <CardTitle className="flex items-center space-x-2">
+              <CreditCard className="h-5 w-5" />
+              <span>Card Information</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="text-center space-y-1">
+              <p className="text-2xl font-mono tracking-widest">
+                {cardDetails.maskedNumber || '****-****-****-****'}
+              </p>
+              <p className="text-muted-foreground text-sm">
+                Expires {cardDetails.expiryMonth}/{cardDetails.expiryYear}
+              </p>
+            </div>
+            <div className="flex justify-between text-sm">
+              <span>Status</span>
+              <span className="font-medium capitalize">{cardDetails.status}</span>
+            </div>
+          </CardContent>
+        </Card>
+      </motion.div>
+    </div>
+  );
+}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -40,6 +40,16 @@ export interface CardStatus {
   authorizedCategory?: string;
 }
 
+export interface CardDetails {
+  id: string;
+  status: string;
+  maskedNumber: string | null;
+  expiryMonth: number;
+  expiryYear: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface AuthorizeRequest {
   amount: number;
   category: string;
@@ -130,6 +140,10 @@ class ApiClient {
   // Card endpoints
   async getCardStatus(): Promise<ApiResponse<CardStatus>> {
     return this.request('/api/card/status');
+  }
+
+  async getCardDetails(): Promise<ApiResponse<CardDetails>> {
+    return this.request('/api/card/details');
   }
 
   async authorizeTransaction(data: AuthorizeRequest): Promise<ApiResponse<{ success: boolean; expiresAt: string }>> {

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -32,18 +32,29 @@ export interface CardStatus {
   authorizedCategory?: string;
 }
 
+export interface CardDetails {
+  id: string;
+  status: string;
+  maskedNumber: string | null;
+  expiryMonth: number;
+  expiryYear: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
 interface AppState {
   // Auth state
   user: User | null;
   isAuthenticated: boolean;
-  
+
   // App state
   budgets: Budget[];
   transactions: Transaction[];
   cardStatus: CardStatus | null;
+  cardDetails: CardDetails | null;
   
   // UI state
-  currentScreen: 'home' | 'authorize' | 'success' | 'post-purchase' | 'history' | 'profile';
+  currentScreen: 'home' | 'authorize' | 'success' | 'post-purchase' | 'history' | 'profile' | 'card';
   isLoading: boolean;
   error: string | null;
   
@@ -52,6 +63,7 @@ interface AppState {
   setBudgets: (budgets: Budget[]) => void;
   setTransactions: (transactions: Transaction[]) => void;
   setCardStatus: (status: CardStatus | null) => void;
+  setCardDetails: (details: CardDetails | null) => void;
   setCurrentScreen: (screen: AppState['currentScreen']) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
@@ -67,6 +79,7 @@ export const useAppStore = create<AppState>()(
       budgets: [],
       transactions: [],
       cardStatus: null,
+      cardDetails: null,
       currentScreen: 'home',
       isLoading: false,
       error: null,
@@ -76,15 +89,17 @@ export const useAppStore = create<AppState>()(
       setBudgets: (budgets) => set({ budgets }),
       setTransactions: (transactions) => set({ transactions }),
       setCardStatus: (cardStatus) => set({ cardStatus }),
+      setCardDetails: (cardDetails) => set({ cardDetails }),
       setCurrentScreen: (currentScreen) => set({ currentScreen }),
       setLoading: (isLoading) => set({ isLoading }),
       setError: (error) => set({ error }),
-      logout: () => set({ 
-        user: null, 
-        isAuthenticated: false, 
-        budgets: [], 
-        transactions: [], 
+      logout: () => set({
+        user: null,
+        isAuthenticated: false,
+        budgets: [],
+        transactions: [],
         cardStatus: null,
+        cardDetails: null,
         currentScreen: 'home'
       }),
     }),


### PR DESCRIPTION
## Summary
- expose card detail endpoint in Api client
- store user's card information in Zustand
- fetch card data after login/registration
- add Card screen and navigation item

## Testing
- `npm test` in `backend`
- `npm test` in `frontend` *(fails: Missing script)*
- `npm run build` in `frontend` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_684753f6fdb48328bcb224f01bf523df