### PR TITLE
Add virtual card intro page

### DIFF
--- a/frontend/components/finlock-app.tsx
+++ b/frontend/components/finlock-app.tsx
@@ -11,10 +11,11 @@ import { SuccessScreen } from '@/components/screens/success-screen';
 import { PostPurchaseScreen } from '@/components/screens/post-purchase-screen';
 import { HistoryScreen } from '@/components/screens/history-screen';
 import { ProfileScreen } from '@/components/screens/profile-screen';
+import { IntroScreen } from '@/components/screens/intro-screen';
 import { apiClient } from '@/lib/api';
 
 export function FinLockApp() {
-  const { isAuthenticated, currentScreen, setLoading } = useAppStore();
+  const { isAuthenticated, currentScreen, introCompleted, setCurrentScreen, setLoading } = useAppStore();
 
   useEffect(() => {
     // Initialize app
@@ -28,6 +29,12 @@ export function FinLockApp() {
       }
     }
   }, [setLoading]);
+
+  useEffect(() => {
+    if (isAuthenticated && !introCompleted) {
+      setCurrentScreen('intro');
+    }
+  }, [isAuthenticated, introCompleted, setCurrentScreen]);
 
   if (!isAuthenticated) {
     return <AuthScreen />;
@@ -47,6 +54,8 @@ export function FinLockApp() {
         return <HistoryScreen />;
       case 'profile':
         return <ProfileScreen />;
+      case 'intro':
+        return <IntroScreen />;
       default:
         return <HomeScreen />;
     }

--- a/frontend/components/layout/mobile-header.tsx
+++ b/frontend/components/layout/mobile-header.tsx
@@ -11,6 +11,7 @@ import {
   Home, 
   CreditCard, 
   History,
+  HelpCircle,
   Menu,
   X
 } from 'lucide-react';
@@ -30,6 +31,7 @@ export function MobileHeader() {
     { id: 'home', label: 'Home', icon: Home },
     { id: 'authorize', label: 'Authorize', icon: CreditCard },
     { id: 'history', label: 'History', icon: History },
+    { id: 'intro', label: 'Card Guide', icon: HelpCircle },
     { id: 'profile', label: 'Profile', icon: User },
   ];
 

--- a/frontend/components/screens/intro-screen.tsx
+++ b/frontend/components/screens/intro-screen.tsx
@@ -1,0 +1,75 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { useAppStore } from '@/lib/store';
+import { HelpCircle, CreditCard, Shield, DollarSign } from 'lucide-react';
+import { motion } from 'framer-motion';
+
+export function IntroScreen() {
+  const { setIntroCompleted, setCurrentScreen } = useAppStore();
+
+  const handleStart = () => {
+    setIntroCompleted(true);
+    setCurrentScreen('home');
+  };
+
+  const steps = [
+    {
+      icon: Shield,
+      title: 'Virtual card created',
+      text: 'FinLock automatically provisions and freezes your card when you sign up.'
+    },
+    {
+      icon: CreditCard,
+      title: 'Authorize before you pay',
+      text: 'Unlock the card from the Authorize tab by choosing an amount and category.'
+    },
+    {
+      icon: DollarSign,
+      title: 'Tap or copy card details',
+      text: 'Use the virtual card for checkout then it re-freezes when done.'
+    },
+    {
+      icon: HelpCircle,
+      title: 'Review anytime',
+      text: 'Visit this guide from the menu whenever you need a refresher.'
+    }
+  ];
+
+  return (
+    <div className="space-y-6 p-4 max-w-xl mx-auto">
+      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }}>
+        <Card className="fintech-card">
+          <CardHeader>
+            <CardTitle className="flex items-center space-x-2">
+              <HelpCircle className="h-5 w-5" />
+              <span>Getting Started</span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {steps.map((step, idx) => {
+              const Icon = step.icon;
+              return (
+                <div key={idx} className="flex items-start space-x-3">
+                  <Icon className="h-5 w-5 text-blue-600 mt-0.5" />
+                  <div>
+                    <p className="font-medium">{step.title}</p>
+                    <p className="text-sm text-muted-foreground">{step.text}</p>
+                  </div>
+                </div>
+              );
+            })}
+          </CardContent>
+        </Card>
+      </motion.div>
+
+      <motion.div initial={{ opacity: 0, y: 20 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: 0.2 }} className="text-center">
+        <Button variant="fintech" size="lg" className="w-full max-w-sm" onClick={handleStart}>
+          Get Started
+        </Button>
+      </motion.div>
+    </div>
+  );
+}
+

--- a/frontend/lib/store.ts
+++ b/frontend/lib/store.ts
@@ -43,9 +43,10 @@ interface AppState {
   cardStatus: CardStatus | null;
   
   // UI state
-  currentScreen: 'home' | 'authorize' | 'success' | 'post-purchase' | 'history' | 'profile';
+  currentScreen: 'intro' | 'home' | 'authorize' | 'success' | 'post-purchase' | 'history' | 'profile';
   isLoading: boolean;
   error: string | null;
+  introCompleted: boolean;
   
   // Actions
   setUser: (user: User | null) => void;
@@ -55,6 +56,7 @@ interface AppState {
   setCurrentScreen: (screen: AppState['currentScreen']) => void;
   setLoading: (loading: boolean) => void;
   setError: (error: string | null) => void;
+  setIntroCompleted: (completed: boolean) => void;
   logout: () => void;
 }
 
@@ -70,6 +72,7 @@ export const useAppStore = create<AppState>()(
       currentScreen: 'home',
       isLoading: false,
       error: null,
+      introCompleted: false,
       
       // Actions
       setUser: (user) => set({ user, isAuthenticated: !!user }),
@@ -79,20 +82,23 @@ export const useAppStore = create<AppState>()(
       setCurrentScreen: (currentScreen) => set({ currentScreen }),
       setLoading: (isLoading) => set({ isLoading }),
       setError: (error) => set({ error }),
-      logout: () => set({ 
-        user: null, 
-        isAuthenticated: false, 
-        budgets: [], 
-        transactions: [], 
+      setIntroCompleted: (introCompleted) => set({ introCompleted }),
+      logout: () => set({
+        user: null,
+        isAuthenticated: false,
+        budgets: [],
+        transactions: [],
         cardStatus: null,
-        currentScreen: 'home'
+        currentScreen: 'home',
+        introCompleted: false
       }),
     }),
     {
       name: 'finlock-storage',
-      partialize: (state) => ({ 
-        user: state.user, 
-        isAuthenticated: state.isAuthenticated 
+      partialize: (state) => ({
+        user: state.user,
+        isAuthenticated: state.isAuthenticated,
+        introCompleted: state.introCompleted
       }),
     }
   )


### PR DESCRIPTION
## Summary
- create `IntroScreen` to guide new users on virtual card usage
- persist `introCompleted` flag in the store
- show intro on first login and add guide to navigation

## Testing
- `npm install`
- `npm run lint` *(fails: requires interactive setup)*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68475312b8408328a5f2362aa22d3d23