### PR TITLE
Fix missing CardScreen import

### DIFF
--- a/frontend/components/finlock-app.tsx
+++ b/frontend/components/finlock-app.tsx
@@ -12,6 +12,7 @@ import { PostPurchaseScreen } from '@/components/screens/post-purchase-screen';
 import { HistoryScreen } from '@/components/screens/history-screen';
 import { ProfileScreen } from '@/components/screens/profile-screen';
 import { IntroScreen } from '@/components/screens/intro-screen';
+import { CardScreen } from '@/components/screens/card-screen';
 import { apiClient } from '@/lib/api';
 
 export function FinLockApp() {


### PR DESCRIPTION
## Summary
- add CardScreen import in FinLockApp

## Testing
- `npm test` in `backend`
- `npm run lint` in `frontend` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847584c61b08328b2565d159f85966a